### PR TITLE
docs: update outdated org name

### DIFF
--- a/.github/workflows/check-for-clc.yaml
+++ b/.github/workflows/check-for-clc.yaml
@@ -18,12 +18,12 @@ jobs:
     steps:
       - name: "CLC Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLC Document and I hereby sign the CLC') || github.event_name == 'pull_request_target'
-        uses: commune-os/clc-assistant@master
+        uses: muni-town/clc-assistant@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/commune-os/weird/blob/a583615a9d34d913f5e63065768cdbe02750ae43/CONTRIBUTING.md' # e.g. a CLA or a DCO document
+          path-to-document: 'https://github.com/muni-town/weird/blob/a583615a9d34d913f5e63065768cdbe02750ae43/CONTRIBUTING.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'clc-signatures'
           allowlist: zicklag,erlend-sh,hnb-ku

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,4 +48,4 @@ The Leaf server can also connect to other Leaf servers though the Leaf protocol.
 eventually allow Weird to federate with other Weird instances, and synchronize with offline-capable
 desktop applications in the future.
 
-[lpd]: https://github.com/commune-os/agentic-fediverse/blob/master/leaf-protocol-draft.md#leaf-protocol-draft
+[lpd]: https://github.com/muni-town/agentic-fediverse/blob/master/leaf-protocol-draft.md#leaf-protocol-draft

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-repository = "https://github.com/commune-os/weird/"
+repository = "https://github.com/muni-town/weird/"
 
 # [patch.crates-io]
 # iroh = { path = "../iroh/iroh" }

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Not essential for groking Weird app development, but useful for broad-view conte
 8. Mutual Peers Grid (p2p net)
 9. Auth v3 (Nomadic ID)
 
-If you want to chat about Weird and our vision for it feel free to join our [Discord Server](https://discord.gg/mbQYgFVBQx) or our bridge [Matrix Space](https://matrix.to/#/#discord:commune.sh).
+If you want to chat about Weird and our vision for it feel free to join our [Discord Server](https://discord.gg/mbQYgFVBQx) or our bridge [Matrix Space](https://matrix.to/#/##muni-town:commune.sh).

--- a/deploy/rauthy/deploy.sh
+++ b/deploy/rauthy/deploy.sh
@@ -10,4 +10,3 @@ kraft cloud deploy \
   -e DATABASE_URL=postgresql://postgres:password@weird-rauthy-postgres.internal/postgres \
   -M 250 \
   khaws/weird-rauthy
-  

--- a/leaf/leaf-protocol/README.md
+++ b/leaf/leaf-protocol/README.md
@@ -13,4 +13,4 @@ It would also have a `NameDescription` component, and maybe a `Slug` component t
 Each chat message would have an `Author` component that would contain a link to another Entity that has the info describing the author of the chat. The author, for example, would have an Image component that would be used for their avatar, as well as a `NameDescription`, and a `Slug` ( we should discuss a standard component for `Slug` or `MachineName` or something eventually ).
 In Rust, each component will be a Rust struct or Enum that derives `BorshSerialize` and `BorshDeserialize`, as well as custom `HasBorshSchema`, and `Component` traits.
 
-[lp]: https://github.com/commune-os/agentic-fediverse/blob/main/leaf-protocol-draft.md
+[lp]: https://github.com/muni-town/agentic-fediverse/blob/main/leaf-protocol-draft.md

--- a/leaf/leaf-protocol/src/lib.rs
+++ b/leaf/leaf-protocol/src/lib.rs
@@ -1,6 +1,6 @@
 //! Rust implementation of the [Leaf Protocol draft][lp].
 //!
-//! [lp]: https://github.com/commune-os/agentic-fediverse/blob/49791e6b3ec1df5e0a8604476417e88eed1f9497/leaf-protocol-draft.md
+//! [lp]: https://github.com/muni-town/agentic-fediverse/blob/49791e6b3ec1df5e0a8604476417e88eed1f9497/leaf-protocol-draft.md
 
 pub mod components;
 pub mod store;

--- a/leaf/ts/README.md
+++ b/leaf/ts/README.md
@@ -3,4 +3,4 @@
 TypeScript library for the [Leaf Protocol][lp]. Currently just contains a Leaf RPC client implementation
 and it depends on a Leaf Protocol RPC server.
 
-[lp]: https://github.com/commune-os/agentic-fediverse/blob/main/leaf-protocol-draft.md#leaf-protocol-draft
+[lp]: https://github.com/muni-town/agentic-fediverse/blob/main/leaf-protocol-draft.md#leaf-protocol-draft

--- a/leaf/ts/package.json
+++ b/leaf/ts/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"description": "Leaf protocol RPC client.",
 	"keywords": [],
-	"author": "Commune Developers ( https://github.com/commune-os )",
+	"author": "Muni Town Developers ( https://github.com/muni-town )",
 	"license": "BlueOak-1.0.0",
 	"dependencies": {
 		"@noble/hashes": "^1.4.0",


### PR DESCRIPTION
Some infrastructure (like CI and crates.io) will break if GitHub's automated routing stops working and we don't update our organization name in the codebase.

I haven't updated the name of our matrix channel. Is it still the same? @erlend-sh 

```
✦ 🦄 rg commune
README.md
87:If you want to chat about Weird and our vision for it feel free to join our [Discord Server](https://discord.gg/mbQYgFVBQx) or our bridge [Matrix Space](https://matrix.to/#/#discord:commune.sh).
```

