### PR TITLE
docs: add `leaf-protocol` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Essential building blocks:
 
 - SvelteKit
 - [Rauthy](https://github.com/sebadob/rauthy) ([OIDC](https://developer.okta.com/blog/2019/10/21/illustrated-guide-to-oauth-and-oidc))
-- Leaf Server
+- Leaf Server ![Crates.io Version](https://img.shields.io/crates/v/leaf-protocol)
   - Rust
   - [Iroh](https://n0.computer)
   - [Willow](https://n0.computer)


### PR DESCRIPTION
Makes it easier to find on crates.io.