### PR TITLE
refactor: update (app)-auth-v1-users-reset-token to new theming pattern.

### DIFF
--- a/src/routes/(app)/auth/v1/users/[user]/reset/[token]/+page.svelte
+++ b/src/routes/(app)/auth/v1/users/[user]/reset/[token]/+page.svelte
@@ -4,73 +4,21 @@
 	import { onMount } from 'svelte';
 	import type { PageData } from './$types';
 
-	let { data }: { data: PageData } = $props();
+	import ResetPasswordPage from './components/ResetPasswordPage.svelte';
 
-	type Policy = typeof data.passwordPolicy;
-	type PolicyKey = keyof Policy;
-	const passwordValidityLabels: { [K in PolicyKey]: string } = {
-		include_digits: 'Include %s numbers',
-		include_lower_case: 'Include %s lowercase',
-		include_upper_case: 'Include &s uppercase',
-		include_special: 'Include %s special characters',
-		length_max: 'Shorter than %s',
-		length_min: 'At least %s long',
-		not_recently_used: 'Not one of your %s recently used passwords'
-	};
+	const { data }: { data: PageData } = $props();
 
-	let password = $state('');
 	let error = $state('');
-	let passwordValidity: { [K in PolicyKey]?: { label: string; valid?: boolean } } = $state(
-		Object.fromEntries(
-			Object.entries(data.passwordPolicy)
-				.filter(([_, value]) => !!value)
-				.map(([key, value]) => [
-					key,
-					{
-						label: passwordValidityLabels[key as PolicyKey].replace('%s', value.toString()),
-						valid: false
-					}
-				])
-		)
-	);
-	let passwordValid = $derived(Object.values(passwordValidity).every((x) => x.valid));
-
-	$effect(() => {
-		if (passwordValidity.length_min) {
-			passwordValidity.length_min.valid = password.length >= data.passwordPolicy.length_min!;
-		}
-		if (passwordValidity.length_max) {
-			passwordValidity.length_max.valid = password.length <= data.passwordPolicy.length_max!;
-		}
-		if (passwordValidity.include_lower_case) {
-			passwordValidity.include_lower_case!.valid =
-				password.replaceAll(/[a-z]/g, '').length >= data.passwordPolicy.include_lower_case!;
-		}
-		if (passwordValidity.include_upper_case) {
-			passwordValidity.include_upper_case!.valid =
-				password.replaceAll(/[A-Z]/g, '').length >= data.passwordPolicy.include_upper_case!;
-		}
-		if (passwordValidity.include_digits) {
-			passwordValidity.include_digits!.valid =
-				password.replaceAll(/[0-9]/g, '').length >= data.passwordPolicy.include_digits!;
-		}
-		if (passwordValidity.include_special) {
-			passwordValidity.include_special.valid =
-				password.replaceAll(/[!@#$%^&*()]/g, '').length >= data.passwordPolicy.include_special!;
-		}
-		if (passwordValidity.not_recently_used) {
-			passwordValidity.not_recently_used.valid = undefined;
-		}
-	});
 
 	onMount(() => {
 		localStorage.setItem('justResetPassword', 'false');
 	});
 
-	async function onSubmit(e: SubmitEvent) {
+	async function onsubmit(e: SubmitEvent) {
 		e.preventDefault();
 
-		error = '';
+		const formData = new FormData(e.target as HTMLFormElement);
+		const password = formData.get('password') as string;
 
 		try {
 			const resp = await fetch(`/auth/v1/users/${data.user}/reset`, {
@@ -82,60 +30,13 @@
 			localStorage.setItem('justResetPassword', 'true');
 			window.location.replace('/my-profile');
 		} catch (e) {
-			console.log(e);
-			password = '';
-			error = 'Error setting password.';
+			const { data } = e as { data: string };
+			const { message } = JSON.parse(data);
+			error = message;
 		}
 	}
+
+	const pageTitle = `Set Password | ${env.PUBLIC_INSTANCE_NAME}`;
 </script>
 
-<svelte:head>
-	<title>Set Password | {env.PUBLIC_INSTANCE_NAME}</title>
-</svelte:head>
-
-<main class="flex flex-col items-center">
-	{#if data.csrfToken}
-		<form class="card mt-12 flex w-[600px] max-w-[90%] flex-col gap-4 p-8" onsubmit={onSubmit}>
-			<h1 class="my-3 text-2xl">Set Password</h1>
-
-			{#if error}
-				<aside class="alert variant-ghost-error">
-					<div class="alert-message">
-						<p>{error}</p>
-					</div>
-				</aside>
-			{/if}
-
-			<p>Set a new password for your account.</p>
-			<label class="label">
-				<span>Password</span>
-				<input
-					name="password"
-					class="input"
-					type="password"
-					placeholder="Password"
-					bind:value={password}
-				/>
-				<div class="pl-4 text-sm">
-					{#each Object.values(passwordValidity) as check}
-						<div class="">
-							{check.valid == undefined ? '⭕' : check.valid ? '✅' : '❌'}
-							{check.label}
-						</div>
-					{/each}
-				</div>
-			</label>
-
-			<button class="variant-filled btn" disabled={!passwordValid}> Set Password </button>
-		</form>
-	{:else}
-		<aside class="alert variant-ghost-error m-8">
-			<div class="alert-message">
-				<p>
-					This password reset link has expired, please request a new one if you still need to reset
-					your password.
-				</p>
-			</div>
-		</aside>
-	{/if}
-</main>
+<ResetPasswordPage {pageTitle} {error} {onsubmit} csrfToken={data.csrfToken} />

--- a/src/routes/(app)/auth/v1/users/[user]/reset/[token]/+page.ts
+++ b/src/routes/(app)/auth/v1/users/[user]/reset/[token]/+page.ts
@@ -3,39 +3,15 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ params, fetch }) => {
 	const { user, token } = params;
 	let csrfToken: string | undefined;
-	let passwordPolicy: {
-		length_min?: number;
-		length_max?: number;
-		include_lower_case?: number;
-		include_upper_case?: number;
-		include_digits?: number;
-		include_special?: number;
-		not_recently_used?: number;
-	} = {};
 	try {
 		const initResp = await fetch(`/auth/v1/users/${user}/reset/${token}`, {});
 		const initContent = await initResp.text();
 		const csrfFind = 'name="rauthy-csrf-token" id="';
 		let contentSplit = initContent.split(csrfFind)[1];
 		csrfToken = contentSplit.split('"')[0];
-		const passwordPolicyFind = 'name="rauthy-data" id="';
-		contentSplit = initContent.split(passwordPolicyFind)[1];
-		const arr = contentSplit
-			.split('"')[0]
-			.split(',')
-			.map((x) => (x == '-1' ? undefined : Number.parseInt(x)));
-		passwordPolicy = {
-			length_min: arr[0],
-			length_max: arr[1],
-			include_lower_case: arr[2],
-			include_upper_case: arr[3],
-			include_digits: arr[4],
-			include_special: arr[5],
-			not_recently_used: arr[6]
-		};
 	} catch (e) {
 		console.error('error loading reset page', e);
 	}
 
-	return { csrfToken, user, token, passwordPolicy };
+	return { csrfToken, user, token };
 };

--- a/src/routes/(app)/auth/v1/users/[user]/reset/[token]/components/ResetPasswordForm.svelte
+++ b/src/routes/(app)/auth/v1/users/[user]/reset/[token]/components/ResetPasswordForm.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	interface Props {
+		error: string;
+		onsubmit: (event: SubmitEvent) => void;
+	}
+
+	const { error, onsubmit }: Props = $props();
+</script>
+
+<form class="card mt-12 flex w-[600px] max-w-[90%] flex-col gap-4 p-8" {onsubmit}>
+	<h1 class="my-3 text-2xl">Set Password</h1>
+
+	{#if error}
+		<aside class="alert variant-ghost-error">
+			<div class="alert-message">
+				<p>{error}</p>
+			</div>
+		</aside>
+	{/if}
+
+	<p>Set a new password for your account.</p>
+	<label class="label">
+		<span>Password</span>
+		<input name="password" class="input" type="password" placeholder="Password" />
+	</label>
+
+	<button type="submit" class="variant-filled btn">Set Password</button>
+</form>

--- a/src/routes/(app)/auth/v1/users/[user]/reset/[token]/components/ResetPasswordPage.svelte
+++ b/src/routes/(app)/auth/v1/users/[user]/reset/[token]/components/ResetPasswordPage.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	interface props {
+		pageTitle: string;
+		csrfToken: string | undefined;
+		error: string;
+		onsubmit: (event: SubmitEvent) => void;
+	}
+
+	import ResetPasswordForm from './ResetPasswordForm.svelte';
+
+	const { pageTitle, csrfToken, error, onsubmit }: props = $props();
+</script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+</svelte:head>
+
+<main class="flex flex-col items-center">
+	{#if csrfToken}
+		<ResetPasswordForm {error} {onsubmit} />
+	{:else}
+		<aside class="alert variant-ghost-error m-8">
+			<div class="alert-message">
+				<p>
+					This password reset link has expired, please request a new one if you still need to reset
+					your password.
+				</p>
+			</div>
+		</aside>
+	{/if}
+</main>


### PR DESCRIPTION
This is part of https://github.com/muni-town/weird/issues/187, more details can be found there.

This refactor is a little bit different from the other ones.

Right now we have something like this:

<img width="357" alt="image" src="https://github.com/user-attachments/assets/5afb4fe5-b50b-4e87-85d7-6d3cafc73c36">

This works great because we relay the password policy from Rauthy.

This PR proposes a slightly different way to do the same. Instead of doing the password validation again in the Svelte app, we just surface the errors from Rauthy directly.

The idea here is that it simplifies the app-side route a bit while also reducing the amount of information users have to process.

The PR makes the errors show one at a time and let users update the password (while keeping what they already typed). We get the errors directly from Rauthy.

It looks like this

<img width="356" alt="image" src="https://github.com/user-attachments/assets/9c655b46-cc8e-431a-bc9b-1889ca864bdb">

and so on. Users can work through the errors one by one.

Server-load is not a concern here because that form won't show unless we have a csrf token (which is also generated by Rauthy) The form won't display if front-end doesn't get a csrf token from the backend.

The result is that we directly display the errors from Rauthy in the app, but we still control how things look. 

As a side-note: I think the current password policy defaults lean too much on the "safe" side and we might be ok relaxing some of them to make the process a bit easier from a UX perspective.

