### PR TITLE
feat: add admin data explorer.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,3 +115,17 @@ You can do this by running `just comply` followed by `just check`.
 
 <!-- dprint-ignore -->
 [blue-oak]: https://writing.kemitchell.com/2019/03/09/Deprecation-Notice.html
+
+## Debugging Tools
+
+Users that have the `admin` role, as configured in Rauthy are able to access the Weird admin menu
+from the app nav toolbar or by going to
+[`http://localhost:9523/__internal__/admin`](http://localhost:9523/__internal__/admin).
+
+At the time of writing this includes:
+
+- A database dump / restore feature
+- A database data explorer
+- A utility to update the username domain for all users on the instance
+
+More utilities may be added in the future as we find time and deem necessary.

--- a/leaf/leaf-protocol/src/lib.rs
+++ b/leaf/leaf-protocol/src/lib.rs
@@ -57,6 +57,7 @@ pub struct Leaf<Store: LeafStore> {
     pub store: Store,
 }
 
+#[derive(Debug)]
 pub enum EntityEntry<S: LeafStore> {
     Entity(LoadedEntity<S>),
     Empty { link: ExactLink, store: S },

--- a/leaf/leaf-rpc-proto/src/lib.rs
+++ b/leaf/leaf-rpc-proto/src/lib.rs
@@ -54,6 +54,8 @@ pub enum ReqKind {
     ListLocalSecrets,
     CreateDatabaseDump,
     RestoreDatabaseDump(DatabaseDump),
+    ListNamespaces,
+    ListSubspaces,
 }
 
 #[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Debug)]
@@ -82,6 +84,8 @@ pub enum RespKind {
     ListLocalSecrets(HashMap<String, String>),
     CreateDatabaseDump(DatabaseDump),
     RestoreDatabaseDump,
+    ListNamespaces(Vec<NamespaceId>),
+    ListSubspaces(Vec<SubspaceId>),
 }
 
 #[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Debug, Default)]

--- a/src/lib/leaf/index.ts
+++ b/src/lib/leaf/index.ts
@@ -9,6 +9,8 @@ import {
 	type PathSegment,
 	type ExactLink
 } from 'leaf-proto';
+import { CommonMark, Description, Name } from 'leaf-proto/components';
+import { Username, Tags, WebLinks, WeirdCustomDomain, WeirdPubpageTheme } from './profile';
 
 /** The Leaf RPC client used to connect to our backend data server. */
 export let leafClient: RpcClient = null as any;
@@ -58,4 +60,44 @@ this secret when running the server next, to keep using the same data:',
 	console.log(`Leaf client initialized:
     Weird Namespace ID        : ${base32Encode(WEIRD_NAMESPACE)}
     Weird Instance Subspace ID: ${base32Encode(INSTANCE_SUBSPACE)}`);
+}
+
+export type KnownComponents = {
+	name?: Name['value'];
+	description?: Description['value'];
+	username?: Username['value'];
+	tags?: Tags['value'];
+	webLinks?: WebLinks['value'];
+	weirdPubpageTheme?: WeirdPubpageTheme['value'];
+	weirdCustomDomain?: WeirdCustomDomain['value'];
+	commonmark?: CommonMark['value'];
+};
+
+export async function loadKnownComponents(link: ExactLink): Promise<KnownComponents | undefined> {
+	const ent = await leafClient.get_components(
+		link,
+		Name,
+		Description,
+		Username,
+		Tags,
+		WebLinks,
+		WeirdPubpageTheme,
+		WeirdCustomDomain,
+		CommonMark
+	);
+
+	if (ent) {
+		return {
+			name: ent.get(Name)?.value,
+			description: ent.get(Description)?.value,
+			username: ent.get(Username)?.value,
+			tags: ent.get(Tags)?.value,
+			webLinks: ent.get(WebLinks)?.value,
+			weirdPubpageTheme: ent.get(WeirdPubpageTheme)?.value,
+			weirdCustomDomain: ent.get(WeirdCustomDomain)?.value,
+			commonmark: ent.get(CommonMark)?.value
+		};
+	} else {
+		return;
+	}
 }

--- a/src/lib/utils/databaseDump.ts
+++ b/src/lib/utils/databaseDump.ts
@@ -1,4 +1,10 @@
-import { base32Encode, Component, type DatabaseDump, type EntityPath } from 'leaf-proto';
+import {
+	base32Encode,
+	Component,
+	formatEntityPath,
+	type DatabaseDump,
+	type EntityPath
+} from 'leaf-proto';
 import _ from 'underscore';
 
 export function prettyPrintDump(
@@ -6,7 +12,6 @@ export function prettyPrintDump(
 	knownComponents: (new (...any: any) => Component)[]
 ): string {
 	let result = '';
-	const s = (n: number) => ' '.repeat(n * 2);
 	const p = (n: number, ...args: any) => {
 		result += `${' '.repeat(n * 2)} ${args.join(' ')}\n`;
 	};
@@ -28,7 +33,7 @@ export function prettyPrintDump(
 			for (const [path, ent] of entities) {
 				p(5, `${formatEntityPath(path)}: ${e(ent.digest)}`);
 
-				for (let [schema, datas] of ent.components) {
+				for (let [schema, data] of ent.components) {
 					schema = new Uint8Array(schema);
 
 					let known = false;
@@ -36,7 +41,7 @@ export function prettyPrintDump(
 						if (_.isEqual(knownComponent.schemaId(), schema)) {
 							known = true;
 
-							for (const data of datas) {
+							for (const data of data) {
 								try {
 									const comp = knownComponent.deserialize(new Uint8Array(data));
 									if (data.length < 1024) {
@@ -62,18 +67,4 @@ export function prettyPrintDump(
 	}
 
 	return result;
-}
-
-function formatEntityPath(p: EntityPath): string {
-	let s = '';
-	for (const segment of p) {
-		if ('String' in segment) {
-			s += `/${segment.String}`;
-		} else if ('Bytes' in segment) {
-			s += `/${base32Encode(new Uint8Array(segment.Bytes))}`;
-		} else {
-			s += `/${JSON.stringify(segment)}`;
-		}
-	}
-	return s;
 }

--- a/src/routes/(app)/[username]/+page.svelte
+++ b/src/routes/(app)/[username]/+page.svelte
@@ -126,7 +126,8 @@
 			editingState.profile = data.profile;
 			if (!editingState.profile.bio) editingState.profile.bio = '';
 			if (!editingState.profile.bio)
-				editingState.profile.display_name = data.profile.username?.split('@')[0];
+				editingState.profile.display_name =
+					data.profile.display_name || data.profile.username?.split('@')[0];
 
 			editingState.editing = true;
 			editingTagsState = data.profile.tags.join(', ');

--- a/src/routes/(app)/[username]/[slug]/+page.server.ts
+++ b/src/routes/(app)/[username]/[slug]/+page.server.ts
@@ -73,7 +73,7 @@ export const actions = {
 			await leafClient.del_entity(oldPageLink);
 		}
 
-		await leafClient.updateComponents(pageLink, [
+		await leafClient.update_components(pageLink, [
 			new Name(data.display_name),
 			data.markdown.length > 0 ? new CommonMark(data.markdown) : CommonMark,
 			data.links.length > 0 ? new WebLinks(data.links) : WebLinks

--- a/src/routes/(app)/[username]/new/+page.server.ts
+++ b/src/routes/(app)/[username]/new/+page.server.ts
@@ -40,7 +40,7 @@ export const actions = {
 		const ent = await leafClient.get_components(pageLink);
 		if (ent) return fail(400, { error: 'Page with that slug already exists.', data });
 
-		await leafClient.updateComponents(pageLink, [
+		await leafClient.update_components(pageLink, [
 			new Name(data.display_name),
 			data.markdown.length > 0 ? new CommonMark(data.markdown) : CommonMark,
 			data.links.length > 0 ? new WebLinks(data.links) : WebLinks

--- a/src/routes/(app)/[username]/new/+page.svelte
+++ b/src/routes/(app)/[username]/new/+page.svelte
@@ -8,7 +8,7 @@
 	import CompositeMarkdownEditor from '$lib/components/editors/CompositeMarkdownEditor.svelte';
 	import LinksEditor from '$lib/components/editors/LinksEditor.svelte';
 
-	const { data, form }: { data: PageData; form: ActionData } = $props();
+	const { form }: { form: ActionData } = $props();
 
 	let page = $state(
 		form?.data || {
@@ -19,7 +19,6 @@
 		}
 	) as Page;
 
-	console.log(form);
 	if (form && form.formData) {
 		form.formData().then((formData) => {
 			const result = Page.safeParse(formData);

--- a/src/routes/(internal)/__internal__/admin/+layout.server.ts
+++ b/src/routes/(internal)/__internal__/admin/+layout.server.ts
@@ -5,7 +5,7 @@ import { error } from '@sveltejs/kit';
 // TODO: Move this logic to a "SessionProvider" component.
 export const load: LayoutServerLoad = async ({ fetch, request }) => {
 	const sessionInfos = await getSession(fetch, request);
-	if (!sessionInfos.sessionInfo?.roles.includes('admin')) {
+	if (!sessionInfos.sessionInfo?.roles?.includes('admin')) {
 		return error(403, 'Access denied');
 	}
 	return sessionInfos;

--- a/src/routes/(internal)/__internal__/admin/+page.svelte
+++ b/src/routes/(internal)/__internal__/admin/+page.svelte
@@ -2,4 +2,5 @@
 	<li><a href="/auth/v1/admin">Auth Server Administration UI</a></li>
 	<li><a href="/__internal__/admin/update-username-domains">Update Username Domains</a></li>
 	<li><a href="/__internal__/admin/database-dump">Database Dump / Restore</a></li>
+	<li><a href="/__internal__/admin/explorer">Data Explorer</a></li>
 </ul>

--- a/src/routes/(internal)/__internal__/admin/database-dump/+page.server.ts
+++ b/src/routes/(internal)/__internal__/admin/database-dump/+page.server.ts
@@ -1,16 +1,10 @@
 import { leafClient } from '$lib/leaf';
-import { getSession } from '$lib/rauthy/server';
 import { DatabaseDumpSchema, borshDeserialize, type DatabaseDump } from 'leaf-proto';
 import type { Actions } from './$types';
-import { error, fail } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 
 export const actions = {
-	restore: async ({ request, fetch }) => {
-		let { sessionInfo } = await getSession(fetch, request);
-		if (!sessionInfo?.roles?.includes('admin')) {
-			return error(403, 'Access denied');
-		}
-
+	restore: async ({ request }) => {
 		try {
 			const formData = await request.formData();
 			const dumpFormData = formData.get('dump');

--- a/src/routes/(internal)/__internal__/admin/explorer/[[namespace]]/[[subspace]]/[[entityPath]]/+page.server.ts
+++ b/src/routes/(internal)/__internal__/admin/explorer/[[namespace]]/[[subspace]]/[[entityPath]]/+page.server.ts
@@ -1,0 +1,145 @@
+import { leafClient, type KnownComponents, loadKnownComponents } from '$lib/leaf';
+import { base32Decode, base32Encode, type EntityPath, type ExactLink } from 'leaf-proto';
+import type { Actions, PageServerLoad } from './$types';
+import { error, fail, redirect } from '@sveltejs/kit';
+import { Tags, Username, WebLinks, WeirdCustomDomain, WeirdPubpageTheme } from '$lib/leaf/profile';
+import { CommonMark, Description, Name } from 'leaf-proto/components';
+import { getSession } from '$lib/rauthy/server';
+
+type Data =
+	| {
+			Namespaces: string[];
+	  }
+	| { Subspaces: string[]; namespace: string }
+	| { Entities: EntityPath[]; namespace: string; subspace: string }
+	| { Entity: EntityPath; namespace: string; subspace: string; components: KnownComponents };
+
+export const load: PageServerLoad = async ({ params }): Promise<Data> => {
+	try {
+		if (!params.namespace) {
+			const namespaces = await leafClient.list_namespaces();
+			return { Namespaces: namespaces.map((x) => base32Encode(x)) };
+		} else if (params.namespace && !params.subspace) {
+			const subspaces = await leafClient.list_subspaces();
+			return { Subspaces: subspaces.map((x) => base32Encode(x)), namespace: params.namespace };
+		} else if (params.namespace && params.subspace && !params.entityPath) {
+			const namespace = base32Decode(params.namespace);
+			const subspace = base32Decode(params.subspace);
+			const links = await leafClient.list_entities({ namespace, subspace, path: [] });
+			return {
+				Entities: links.map((x) => x.path),
+				namespace: params.namespace,
+				subspace: params.subspace
+			};
+		} else if (params.namespace && params.subspace && params.entityPath) {
+			const path = JSON.parse(decodeURIComponent(params.entityPath));
+			const components =
+				(await loadKnownComponents({
+					namespace: base32Decode(params.namespace),
+					subspace: base32Decode(params.subspace),
+					path
+				})) || {};
+
+			return {
+				Entity: path,
+				namespace: params.namespace,
+				subspace: params.subspace,
+				components
+			};
+		}
+
+		return error(404);
+	} catch (_) {
+		return error(404);
+	}
+};
+
+export const actions = {
+	save: async ({ url, request, params, fetch }) => {
+		let { sessionInfo } = await getSession(fetch, request);
+		if (!sessionInfo?.roles?.includes('admin')) {
+			return error(403, 'Access denied');
+		}
+		if (!params.namespace || !params.subspace || !params.entityPath) return fail(404);
+
+		try {
+			const link: ExactLink = {
+				namespace: base32Decode(params.namespace),
+				subspace: base32Decode(params.subspace),
+				path: JSON.parse(decodeURIComponent(params.entityPath))
+			};
+			const components = [];
+
+			const formData = await request.formData();
+
+			let username: string | undefined = formData.get('username')?.toString() || '';
+			if (username == '') username = undefined;
+			components.push(username ? new Username(username) : Username);
+
+			let name: string | undefined = formData.get('name')?.toString() || '';
+			if (name == '') name = undefined;
+			components.push(name ? new Name(name) : Name);
+
+			let description: string | undefined = formData.get('description')?.toString() || '';
+			if (description == '') description = undefined;
+			components.push(description ? new Description(description) : Description);
+
+			let webLinks: string | undefined = formData.get('webLinks')?.toString() || '';
+			if (webLinks == '') webLinks = undefined;
+			components.push(webLinks ? new WebLinks(JSON.parse(webLinks)) : WebLinks);
+
+			let tags: string | undefined = formData.get('tags')?.toString() || '';
+			if (tags == '') tags = undefined;
+			components.push(
+				tags
+					? new Tags(
+							tags
+								.split(',')
+								.map((x) => x.trim())
+								.filter((x) => !!x)
+						)
+					: Tags
+			);
+
+			let pubpageTheme: string | undefined = formData.get('pubpageTheme')?.toString() || '';
+			if (pubpageTheme == '') pubpageTheme = undefined;
+			components.push(pubpageTheme ? new WeirdPubpageTheme(pubpageTheme) : WeirdPubpageTheme);
+
+			// let customDomain: string | undefined = formData.get('customDomain')?.toString() || '';
+			// if (customDomain == '') customDomain = undefined;
+			// components.push(customDomain ? new WeirdCustomDomain(customDomain) : WeirdCustomDomain);
+
+			let commonMark: string | undefined = formData.get('commonMark')?.toString() || '';
+			if (commonMark == '') commonMark = undefined;
+			components.push(commonMark ? new CommonMark(commonMark) : CommonMark);
+
+			await leafClient.update_components(link, components);
+		} catch (e: any) {
+			return fail(400, { error: JSON.stringify(e) });
+		}
+
+		const newUrl = new URL(url);
+		newUrl.search = '';
+		return redirect(302, newUrl);
+	},
+	delete: async ({ params, fetch, request }) => {
+		let { sessionInfo } = await getSession(fetch, request);
+		if (!sessionInfo?.roles?.includes('admin')) {
+			return error(403, 'Access denied');
+		}
+		if (!params.namespace || !params.subspace || !params.entityPath) {
+			return error(404);
+		}
+		try {
+			const link: ExactLink = {
+				namespace: base32Decode(params.namespace),
+				subspace: base32Decode(params.subspace),
+				path: JSON.parse(decodeURIComponent(params.entityPath))
+			};
+			await leafClient.del_entity(link);
+		} catch (e: any) {
+			return fail(400, { error: JSON.stringify(e) });
+		}
+		return redirect(303, `/__internal__/admin/explorer/${params.namespace}/${params.subspace}`);
+	}
+} satisfies Actions;

--- a/src/routes/(internal)/__internal__/admin/explorer/[[namespace]]/[[subspace]]/[[entityPath]]/+page.svelte
+++ b/src/routes/(internal)/__internal__/admin/explorer/[[namespace]]/[[subspace]]/[[entityPath]]/+page.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { formatEntityPath } from 'leaf-proto';
+	import type { ActionData, PageData } from './$types';
+	import type { KnownComponents } from '$lib/leaf';
+
+	const { data, form }: { data: PageData; form: ActionData } = $props();
+
+	const base = `/__internal__/admin/explorer`;
+	let segments = $derived(
+		$page.url.pathname
+			.replace(/^\/__internal__\/admin\/explorer/, '')
+			.split('/')
+			.filter((x) => !!x)
+	);
+	let breadcrumbs = $derived.by(() => {
+		const l: { link: string; label: string }[] = [];
+		for (let i = 0; i < segments.length; i++) {
+			const seg = segments[i];
+			function decodeSeg(str: string): string | undefined {
+				try {
+					const decode = decodeURIComponent(str);
+					const json = JSON.parse(decode);
+					return formatEntityPath(json);
+				} catch (e) {
+					return undefined;
+				}
+			}
+			const decoded = decodeSeg(seg);
+			if (i == segments.length - 1 && !!data.Entity && decoded) {
+				l.push({ label: decoded, link: $page.url.href });
+			} else {
+				l.push({ label: seg, link: `${base}/${segments.slice(0, i + 1).join('/')}` });
+			}
+		}
+		return l;
+	});
+
+	let knownComponents: KnownComponents = $derived(data.components || {});
+	let editingTagsState = $state(data.components?.tags?.join(', ') || '');
+	let editingWebLinksState = $state(JSON.stringify(data.components?.webLinks || [], null, '  '));
+</script>
+
+<article>
+	<div class="breadcrumb">
+		<a href={base}>Explorer</a>
+		{#each breadcrumbs as b}
+			→ <a href={b.link}>{b.label}</a>
+		{/each}
+	</div>
+</article>
+
+{#if data.Namespaces}
+	<h2>Data Explorer</h2>
+
+	<p>
+		This is an administrative data explorer for the Weird server. It will list some of the raw data
+		stored in the database and can be used to do things like edit or delete entities. This is meant
+		as a low level tool to allow manipulation of data when something is broken and it is not
+		possible to fix from the normal app, or when an admin needs to be able to edit the data of other
+		users.
+	</p>
+
+	Namespaces:
+	<ul>
+		{#each data.Namespaces as ns}
+			<li><a href={`${$page.url}/${ns}`} class="font-mono">{ns}</a></li>
+		{/each}
+	</ul>
+{:else if data.Subspaces}
+	Subspaces:
+	<ul>
+		{#each data.Subspaces as ss}
+			<li><a href={`${$page.url}/${ss}`} class="font-mono">{ss}</a></li>
+		{/each}
+	</ul>
+{:else if data.Entities}
+	Entities:
+	<ul>
+		{#each data.Entities as link}
+			<li>
+				<a href={`${$page.url}/${encodeURIComponent(JSON.stringify(link))}`} class="font-mono"
+					>{formatEntityPath(link)}</a
+				>
+			</li>
+		{/each}
+	</ul>
+{:else if data.Entity}
+	<h1>Entity</h1>
+	{#if form?.error}
+		<article class="pico-background-red-550">
+			{form.error}
+		</article>
+	{/if}
+	<form method="post" style="margin-bottom: 8em;">
+		<label>
+			Username
+			<input class="input" name="username" bind:value={knownComponents.username} />
+		</label>
+		<label>
+			Name
+			<input class="input" name="name" bind:value={knownComponents.name} />
+		</label>
+		<label>
+			Description
+			<textarea class="input" name="description" bind:value={knownComponents.description}
+			></textarea>
+		</label>
+		<label>
+			Tags ( Comma Separated )
+			<textarea class="input" name="tags" bind:value={editingTagsState}></textarea>
+		</label>
+		<label>
+			Web Links ( JSON )
+			<textarea class="input" name="webLinks" bind:value={editingWebLinksState}></textarea>
+		</label>
+		<label>
+			Pubpage Theme
+			<input class="input" name="pubpageTheme" bind:value={knownComponents.weirdPubpageTheme} />
+		</label>
+		<label>
+			Custom Domain
+			<input class="input" name="customDomain" bind:value={knownComponents.weirdCustomDomain} />
+		</label>
+		<label>
+			CommonMark
+			<textarea class="input" name="commonMark" bind:value={knownComponents.commonmark}></textarea>
+		</label>
+
+		<button formaction="?/save">Update</button>
+		<button formaction="?/delete">Delete</button>
+	</form>
+{/if}
+
+<style>
+	.breadcrumb {
+		display: flex;
+		gap: 1em;
+		flex-wrap: wrap;
+	}
+</style>

--- a/src/routes/(internal)/__internal__/admin/update-username-domains/+page.server.ts
+++ b/src/routes/(internal)/__internal__/admin/update-username-domains/+page.server.ts
@@ -6,10 +6,6 @@ import { error } from '@sveltejs/kit';
 
 export const actions = {
 	default: async ({ request, fetch }) => {
-		let { sessionInfo } = await getSession(fetch, request);
-		if (!sessionInfo?.roles?.includes('admin')) {
-			return error(403, 'Access denied');
-		}
 		const formData = await request.formData();
 		const domain = formData.get('domain')?.toString();
 		if (!domain) error(400, 'You must provide a domain');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,14 +2,17 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
 
-import { defineConfig } from 'vite';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
 
 export default defineConfig({
 	plugins: [wasm(), topLevelAwait(), sveltekit()],
 	server: {
 		host: '0.0.0.0',
 		port: 9523,
-		strictPort: true
+		strictPort: true,
+		fs: {
+			allow: [searchForWorkspaceRoot(process.cwd())]
+		}
 	},
 	build: {
 		rollupOptions: {


### PR DESCRIPTION
Adds a primitive admin explorer to the admin tools:

`http://localhost:9523/__internal__/admin/explorer`

![image](https://github.com/user-attachments/assets/99d650cb-2d33-4d9e-8088-fb80f98c571e)

- **why we needed it:** There was a bug that allowed you to put slashes in the page slugs, causing a situation where it was impossible to navigate to the page and delete it. This meant we had to have a way, as an admin, to go straight to the data and delete the offending page, so that the user wasn't stuck with the broken page eternally in their listing. We may have to do other, similar kinds of edits over time, so this will enable us to take quick action to fix problems instead of having to produce a migration in code and re-deploy before being able to fix the issue.
- **what it does:** Adds a new page to the admin tools that allows you to see all of the entities in the data and read / modify most of the components that are used by Weird.
- **how it was made:** Added a new RPC endpoint that allowed listing namespaces and subspaces, and otherwise works similar to the recent database dump feature to let you browse all of the entities, and then edit them. 