### PR TITLE
Create LICENSE.md for /leaf

### DIFF
--- a/leaf/LICENSE.md
+++ b/leaf/LICENSE.md
@@ -1,0 +1,10 @@
+Derived from `*/LICENSE.md`:
+
+> Weird source code is Copyright (c) 2024 Weird team ([Erlend Sogge Heggen](https://github.com/erlend-sh/) & [Kapono Haws](https://github.com/zicklag/))
+and licensed as [PolyForm NonCommercial v1.0](https://polyformproject.org/licenses/noncommercial/1.0.0/).
+> 
+> An exception is made for the contents of `/leaf` (...)
+
+All contents of `/leaf` are licensed under [Blue Oak Model License v1.0](https://blueoakcouncil.org/license/1.0.0).
+
+Further information is provided in [CONTRIBUTING.md](https://github.com/muni-town/weird/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
The README in the protocol folder should also me moved up to this space, with a header + link to this license file, as well as links to your leaf writings thus far @zicklag 