### PR TITLE
chore: introduce a `.editorconfig` for TypeScript/Svelte

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,ts,svelte}]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
editorconfig is widely supported in most popular editors today, it helps writing code in different file extensions without having to update editor configuration by hand.

This PR provides an editorconfig for TypeScript and Svelte to use tabs for indentation of size 2 and in general use EOL line feed with newline.