### PR TITLE
fix (app): Fix list elements jumping out of position when dragged

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -15,7 +15,6 @@ input::placeholder {
 
 .card {
 	@apply !rounded-xl !border-[1px] !border-black !bg-pink-300/10;
-	backdrop-filter: blur(2px)
 }
 
 .modal.contents .card {


### PR DESCRIPTION
For reasons I don't understand dragging elements from svelte-sortable-list seems to break when it's parent has a `backdrop-filter`. 